### PR TITLE
fix fc error typo

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -117,7 +117,7 @@ The body of the request sent to the webhook will be a JSON object with the follo
 Below are the current list of messages that could be returned when we run into an issue gathering a payoff via our fulfillment center:
 
 - Lender would not release payoff information because:
-  - Lender would not release information over the phone number
+  - Lender would not release information over phone
   - Need Full Member number
   - Need Full Social Security Number
   - Lender would not release to a third party


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->
fix typo on fc error message