### PR TITLE
add new data points to payoff webhook response

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -88,25 +88,28 @@ Where STRINGIFIED_REQUEST is the JSON of the request body (with no padding/white
 
 The body of the request sent to the webhook will be a JSON object with the following possible keys:
 
-| Key                             | Description                                                                                 | Example                                |
-|---------------------------------| ------------------------------------------------------------------------------------------- |----------------------------------------|
-| payoffId                        | The LossExpress UUID                                                                        | `f94bbd89-e9e0-45ac-a02b-e4d4afad6a8f` |
-| payoffAmount                    | A number containing the amount remaining on the loan                                        | `10222.33`                             |
-| perDiem                         | The per diem for the particular loan                                                        | `2.33`                                 |
-| validThroughDate                | A JSON timestamp for the valid through date                                                 | `2020-08-22T00:00:00.000Z`             |
-| lenderPhoneNumber               | A valid phone number for the lender                                                         | `+12223334444`                         |
-| standardMailingAddress          | Contains a standard mailing address for the lender                                          |
-| overnightMailingAddress         | Contains an overnight mailing address for the lender                                        |
-| accountNumber                   | Contains the account number for the account as provided by the lender                       |
-| eftAccountNumber                | An account number for EFT                                                                   |
-| eftRoutingNumber                | A routing number for EFT                                                                    |
-| eftState                        | The state, as it relates to EFT                                                             | `TX`                                   |
-| eftCity                         | The city, as it relates to EFT                                                              | `DALLAS`                               |
-| eftZipCode                      | The ZIP code, as it relates to EFT                                                          | `75204`                                |
-| success                         | A boolean, stating whether we were able to retrieve the payoff or not                       | `true`                                 |
-| errorMessage                    | If success is false, we will attempt to provide an error message                            |
-| fulfilledBy                     | Can be `"integration"` or `"fulfillment center"`, depending on how the payoff was fulfilled | `integration`                          |
-| customerAuthorizationAttempted  | Can be `true` or `false`, depending on whether verbal customer authorization was utilized to retrieve the payoff. Disabled at the company level by default. | `false`                                    |
+| Key                            | Description                                                                                                                                                 | Example                                |
+|--------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------|
+| packetId                       | The LossExpress UUID                                                                                                                                        | `f94bbd89-e9e0-45ac-a02b-e4d4afad6a8f` |
+| payoffId                       | The LossExpress UUID (Same as above - will be deprecated in future)                                                                                         | `f94bbd89-e9e0-45ac-a02b-e4d4afad6a8f` |
+| orderId                        | The LossExpress UUID for the specific order                                                                                                                 | `61951010-d4a0-48b3-86b6-3908da2b0800` |
+| orderType                      | The type of order that has been requested                                                                                                                   | `Payoff Request`                             |
+| payoffAmount                   | A number containing the amount remaining on the loan                                                                                                        | `10222.33`                             |
+| perDiem                        | The per diem for the particular loan                                                                                                                        | `2.33`                                 |
+| validThroughDate               | A JSON timestamp for the valid through date                                                                                                                 | `2020-08-22T00:00:00.000Z`             |
+| lenderPhoneNumber              | A valid phone number for the lender                                                                                                                         | `+12223334444`                         |
+| standardMailingAddress         | Contains a standard mailing address for the lender                                                                                                          |
+| overnightMailingAddress        | Contains an overnight mailing address for the lender                                                                                                        |
+| accountNumber                  | Contains the account number for the account as provided by the lender                                                                                       |
+| eftAccountNumber               | An account number for EFT                                                                                                                                   |
+| eftRoutingNumber               | A routing number for EFT                                                                                                                                    |
+| eftState                       | The state, as it relates to EFT                                                                                                                             | `TX`                                   |
+| eftCity                        | The city, as it relates to EFT                                                                                                                              | `DALLAS`                               |
+| eftZipCode                     | The ZIP code, as it relates to EFT                                                                                                                          | `75204`                                |
+| success                        | A boolean, stating whether we were able to retrieve the payoff or not                                                                                       | `true`                                 |
+| errorMessage                   | If success is false, we will attempt to provide an error message                                                                                            |
+| fulfilledBy                    | Can be `"integration"` or `"fulfillment center"`, depending on how the payoff was fulfilled                                                                 | `integration`                          |
+| customerAuthorizationAttempted | Can be `true` or `false`, depending on whether verbal customer authorization was utilized to retrieve the payoff. Disabled at the company level by default. | `false`                                |
   
 <aside class="notice">
   Only `payoffId` and `success` are guaranteed to be in any given webhook body sent.


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->

adds packetId, orderId and orderType to payoff webhook response table