### PR TITLE
Adds "Add Orders to Packet" section

### DIFF
--- a/source/includes/_orders.md
+++ b/source/includes/_orders.md
@@ -146,3 +146,74 @@ This route allows cancellation of an entire request, which will subsequently can
 Parameter | Description
 --------- | -----------
 packetId | The LossExpress UUID associated with the packet to be cancelled
+
+
+## Cancel Order Request
+
+> Cancel Order Request Example Response Body:
+
+```json
+{
+  "success": true,
+  "orders": [
+    {
+      "orderId": "d7dfb949-073b-4424-8c7e-195f6f08352c",
+      "orderType": "Bill of Sale",
+      "status": "cancelled"
+    }
+  ]
+}
+```
+
+This route allows cancellation of a particular order in event that it is no longer needed.
+
+### HTTP Request
+
+`DELETE https://{YOUR_BASE_URL}/orders/cancel-order/{orderId}`
+
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+orderId | The LossExpress UUID associated with the order to be cancelled
+
+## Add Order to Packet
+
+> Add Order to Packet Request Example Response Body:
+
+```json
+{
+  "packetId": "c30ae9da-9222-4de5-81fe-fe1ac590fa0f",
+  "orders": [
+    {
+      "type": "Payoff Request",
+      "orderId": "3e8c38f3-f4ef-4414-88da-1793d25ef6f0",
+    },
+    {
+      "orderId": "77462941-7b6c-4bd0-9749-588c32654864",
+      "type": "Bill of Sale"
+    }
+  ],
+  "success": true
+}
+```
+
+This route allows a user to add an order to an existing packet. This will only add an order if an existing order of the same type is not currently pending.
+
+The VIN must match the vin of the initial packet request.
+This will throw `success: false` if no orders are added due to the above.
+
+### HTTP Request
+
+`POST https://{YOUR_BASE_URL}/orders/add-orders/{packetId}`
+
+### URL Parameters
+
+URL Parameter | Description
+--------- | -----------
+packetId | The LossExpress UUID associated with the packet 
+
+Body Parameters | Description
+--------- | -----------
+vin | Vehicle Identification Number                                                                                                                                                               | Y | N
+types | An array of the types of orders for the request      

--- a/source/includes/_orders.md
+++ b/source/includes/_orders.md
@@ -200,7 +200,7 @@ orderId | The LossExpress UUID associated with the order to be cancelled
 
 This route allows a user to add an order to an existing packet. This will only add an order if an existing order of the same type is not currently pending.
 
-The VIN must match the vin of the initial packet request.
+The VIN must match the VIN of the initial packet request.
 This will throw `success: false` if no orders are added due to the above.
 
 ### HTTP Request

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -18,6 +18,10 @@ Welcome to the LossExpress xPayoff API! You can utilize this API to get pertinen
 
 # Updates
 
+**2023-03-10**
+
+- New `Add Order to Packet` route added in [Orders](#add-order-to-packet)
+
 **2023-01-04**
 
 - New `Account is delinquent` fulfillment center error message added in [Webhook Body](#webhook-body)


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->

Adds new section explaining new route to add orders to existing packets.
Only to be merged once corresponding [PR](https://github.com/Fastlane-LLC/xpayoff-api/pull/552/) is deployed.

![Screenshot 2023-03-10 at 16 57 55](https://user-images.githubusercontent.com/25518370/224443711-222151c7-90b2-40df-b3a2-a7c3be57b5df.png)

![Screenshot 2023-03-10 at 16 57 10](https://user-images.githubusercontent.com/25518370/224443710-81c03c6c-9ba6-4800-9a92-1d3964e87b0c.png)

