### PR TITLE
Update "paid off" error name

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -277,7 +277,7 @@ Below are the current list of messages that could be returned when we run into a
 - Customer would not authorize
 - Date of birth required
 - Lender would not release to a third party
-- Loan has been paid off
+- Account is closed or paid off
 - Required to be sent via email
 - Required to be sent via fax
 - Social Security number required


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->

![Screenshot 2023-04-10 at 14 28 39](https://user-images.githubusercontent.com/25518370/230981283-3ba545d0-9140-4baa-bee7-01d526c24c29.png)

Updated "Loan has been paid off" to "Account is closed or paid off"

Merge this once https://github.com/Fastlane-LLC/xpayoff-api/pull/584 is merged. (No github actions for xpayoff-docs)
